### PR TITLE
EndpointID and ControllerID switched

### DIFF
--- a/ZWave/CommandClasses/MultiChannelReport.cs
+++ b/ZWave/CommandClasses/MultiChannelReport.cs
@@ -20,8 +20,8 @@ namespace ZWave.CommandClasses
             if (payload.Length < 3)
                 throw new ReponseFormatException($"The response was not in the expected format. {GetType().Name}: Payload: {BitConverter.ToString(payload)}");
 
-            ControllerID = payload[0];
-            EndPointID = payload[1];
+            EndPointID = payload[0];
+            ControllerID = payload[1];
 
             // check sub report
             if(payload.Length > 3 && payload[2] == 37 && payload[3] == 3)


### PR DESCRIPTION
According to my experience the endpointID comes first (index 0) in the payload (verified with all of my MultiInstance devices)
The second index turns out not to be the controllerID, but the destination endpoint id (I think to support direct association between instances from one multichannel device to another, although I'm not sure because I don't have such associations :-)
This doc is helpful: http://z-wave.sigmadesigns.com/wp-content/uploads/2016/08/SDS12657-12-Z-Wave-Command-Class-Specification-A-M.pdf
-> page 484 in this case.