### PR TITLE
SwitchMultiLevel and GenericType updates

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*.cs]
+indent_size = 4
+indent_style = space
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/ZWave/CommandClasses/SwitchMultiLevel.cs
+++ b/ZWave/CommandClasses/SwitchMultiLevel.cs
@@ -10,10 +10,9 @@ namespace ZWave.CommandClasses
     {
         enum command : byte
         {
-            //SupportedGet = 0x01,
-            //SupportedReport = 0x02,
-            Get = 0x04,
-            Report = 0x05
+            Set = 0x01,
+            Get = 0x02,
+            Report = 0x03
         }
 
         public event EventHandler<ReportEventArgs<SwitchMultiLevelReport>> Changed;
@@ -28,7 +27,12 @@ namespace ZWave.CommandClasses
             return new SwitchMultiLevelReport(Node, response);
         }
 
-        protected internal override void HandleEvent(Command command)
+		public async Task Set(byte value)
+		{
+			await Channel.Send(Node, new Command(Class, command.Set, value));
+		}
+
+		protected internal override void HandleEvent(Command command)
         {
             base.HandleEvent(command);
 

--- a/ZWave/GenericType.cs
+++ b/ZWave/GenericType.cs
@@ -7,12 +7,13 @@ namespace ZWave
     public enum GenericType : byte
     {
         Unknown = 0x00,
-        PortableRemote = 0x01,
+        GenericController = 0x01,
         StaticController = 0x02,
         AVControlPoint = 0x03,
-        RoutingSlave = 0x04,
-        Display = 0x06,
-        GarageDoor = 0x07,
+        Display = 0x04,
+        NetworkExtender = 0x05,
+        Appliance = 0x06,
+        SensorNotification = 0x07,
         Thermostat = 0x08,
         WindowCovering = 0x09,
         RepeaterSlave = 0x0F,
@@ -20,13 +21,17 @@ namespace ZWave
         SwitchMultiLevel = 0x11,
         SwitchRemote = 0x12,
         SwitchToggle = 0x13,
+        ZipNode = 0x15,
+        Ventilation = 0x16,
+        SecurityPanel = 0x17,
+        WallController = 0x18,
         SensorBinary = 0x20,
         SensorMultiLevel = 0x21,
-        WaterControl = 0x22,
         MeterPulse = 0x30,
+        Meter = 0x31,
         EntryControl = 0x40,
         SemiInteroperable = 0x50,
-        SmokeDetector = 0xA1,
+        SensorAlarm = 0xA1,
         NonInteroperable = 0xFF
     }
 }


### PR DESCRIPTION
Hi there,

I've done a little work on SwitchMultiLevel and GenericType.

SwitchMultiLevel didn't have a Set method, so I've added that. I also changed the command enum because it looked like the values were not correct - please review this because I'm not really sure if I've done the right thing :)

On GenericType, my Everspring SP816 motion sensors were being reported as Garage Doors, so I took a look at the GenericType enum and updated it in accordance to what I hope is the [latest spec](http://z-wave.sigmadesigns.com/wp-content/uploads/2016/08/SDS13740-1-Z-Wave-Plus-Device-and-Command-Class-Types-and-Defines-Specification.pdf).

I also took the liberty of adding a simple .editorconfig to avoid me and other contributors getting the tab / space settings wrong.

Thanks for creating this library, it has given me a lot of fun trying to get my own home security system off the ground!