### PR TITLE
Improve multi channel support

### DIFF
--- a/ZWave/Channel/CommandClass.cs
+++ b/ZWave/Channel/CommandClass.cs
@@ -22,6 +22,7 @@
         WakeUp = 0x84,
         Association = 0x85,
         Version = 0x86,
+        MultiChannelAssociation = 0x8E,
         SensorAlarm = 0x9C,
     }
 }

--- a/ZWave/Channel/Extentions.cs
+++ b/ZWave/Channel/Extentions.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace ZWave.Channel
@@ -19,6 +17,11 @@ namespace ZWave.Channel
         public static Task<byte[]> Send(this ZWaveChannel channel, Node node, Command command, Enum responseCommand)
         {
             return channel.Send(node.NodeID, command, Convert.ToByte(responseCommand));
+        }
+
+        public static Task<byte[]> Send(this ZWaveChannel channel, Node node, Command command, Enum responseCommand, Func<byte[], bool> payloadValidation)
+        {
+            return channel.Send(node.NodeID, command, Convert.ToByte(responseCommand), payloadValidation);
         }
     }
 }

--- a/ZWave/CommandClasses/EndpointSupportedCommandClassBase.cs
+++ b/ZWave/CommandClasses/EndpointSupportedCommandClassBase.cs
@@ -37,7 +37,7 @@ namespace ZWave.CommandClasses
             else
             {
                 Command encapsolatedCommand = await EncapsulatCommandForEndpoint(command);
-                byte[] response = await Channel.Send(Node, encapsolatedCommand, MultiChannel.command.Encap, EncapsulatCommandEndpointValidator);
+                byte[] response = await Channel.Send(Node, encapsolatedCommand, MultiChannel.command.Encap, EncapsulatCommandEndpointValidator(responseCommand));
                 return ExtractEndpointResponse(response, responseCommand);
             }
         }
@@ -101,9 +101,9 @@ namespace ZWave.CommandClasses
             return response.Skip(4).ToArray();
         }
 
-        private bool EncapsulatCommandEndpointValidator(byte[] payload)
+        private Func<byte[], bool> EncapsulatCommandEndpointValidator(Enum responseCommand)
         {
-            return payload.Length > 0 && payload[0] == _endpointId;
+            return payload => payload.Length >= 4 && payload[0] == _endpointId && payload[3] == Convert.ToByte(responseCommand);
         }
     }
 }

--- a/ZWave/CommandClasses/EndpointSupportedCommandClassBase.cs
+++ b/ZWave/CommandClasses/EndpointSupportedCommandClassBase.cs
@@ -37,7 +37,7 @@ namespace ZWave.CommandClasses
             else
             {
                 Command encapsolatedCommand = await EncapsulatCommandForEndpoint(command);
-                byte[] response = await Channel.Send(Node, encapsolatedCommand, MultiChannel.command.Encap);
+                byte[] response = await Channel.Send(Node, encapsolatedCommand, MultiChannel.command.Encap, EncapsulatCommandEndpointValidator);
                 return ExtractEndpointResponse(response, responseCommand);
             }
         }
@@ -55,6 +55,11 @@ namespace ZWave.CommandClasses
                 Command encapsolatedCommand = await EncapsulatCommandForEndpoint(command);
                 await Channel.Send(Node, encapsolatedCommand);
             }
+        }
+
+        internal void HandleEndpointReport(byte[] wrappedPayload, byte reportType)
+        {
+            HandleEvent(new Command(Class, reportType, wrappedPayload));
         }
 
         private async Task<Command> EncapsulatCommandForEndpoint(Command command)
@@ -94,6 +99,11 @@ namespace ZWave.CommandClasses
             }
 
             return response.Skip(4).ToArray();
+        }
+
+        private bool EncapsulatCommandEndpointValidator(byte[] payload)
+        {
+            return payload.Length > 0 && payload[0] == _endpointId;
         }
     }
 }

--- a/ZWave/CommandClasses/MultiChannel.cs
+++ b/ZWave/CommandClasses/MultiChannel.cs
@@ -1,12 +1,20 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using ZWave.Channel;
+using ZWave.Channel.Protocol;
 
 namespace ZWave.CommandClasses
 {
     public class MultiChannel : CommandClassBase
     {
+        // This dictionary maps each endpoint id and command class type to it's instance.
+        // We cache this so we can notify the command classes on event.
+        //
+        private IDictionary<byte, IDictionary<Type, EndpointSupportedCommandClassBase>> _endpointCommandClasses = new Dictionary<byte, IDictionary<Type, EndpointSupportedCommandClassBase>>();
+
         public enum command
         {
             EndPointGet = 0x07,
@@ -16,6 +24,7 @@ namespace ZWave.CommandClasses
             Encap = 0x0d,
         }
 
+        [Obsolete("Changed event is deprecated, please use the endpoint command classes instead.")]
         public event EventHandler<ReportEventArgs<MultiChannelReport>> Changed;
 
         public MultiChannel(Node node)
@@ -59,23 +68,43 @@ namespace ZWave.CommandClasses
             return new MultiChannelCapabilityReport(Node, response);
         }
 
-        public T GetEndPointCommandClass<T>(byte endPointId) where T : ICommandClass
+        public T GetEndPointCommandClass<T>(byte endPointId) where T : EndpointSupportedCommandClassBase
         {
             if (endPointId == 0)
                 throw new ArgumentException("Endpoint id must be grater then 0.", nameof(endPointId));
 
-            // All supported command classes must have constructor that accept 2 arguments - the node and the endpoint id.
-            //
-            ConstructorInfo constructor = GetCommandClassConstructor<T>();
-            if (constructor == null)
+            lock(_endpointCommandClasses)
             {
-                throw new NotSupportedException($"{GetType()} not supporting command class {typeof(T)}");
-            }
+                // Search for cached instance. If exist, return it.
+                //
+                if (_endpointCommandClasses.ContainsKey(endPointId) && _endpointCommandClasses[endPointId].ContainsKey(typeof(T)))
+                {
+                    return (T)_endpointCommandClasses[endPointId][typeof(T)];
+                }
 
-            return (T)constructor.Invoke(new object[] { Node, endPointId });
+                // All supported command classes must have constructor that accept 2 arguments - the node and the endpoint id.
+                //
+                ConstructorInfo constructor = GetCommandClassConstructor<T>();
+                if (constructor == null)
+                {
+                    throw new NotSupportedException($"{GetType()} not supporting command class {typeof(T)}");
+                }
+
+                T res = (T)constructor.Invoke(new object[] { Node, endPointId });
+
+                // Cache this instance for future use.
+                //
+                if (!_endpointCommandClasses.ContainsKey(endPointId))
+                {
+                    _endpointCommandClasses[endPointId] = new Dictionary<Type, EndpointSupportedCommandClassBase>();
+                }
+
+                _endpointCommandClasses[endPointId][typeof(T)] = res;
+                return res;
+            }
         }
 
-        private static ConstructorInfo GetCommandClassConstructor<T>() where T : ICommandClass
+        private static ConstructorInfo GetCommandClassConstructor<T>() where T : EndpointSupportedCommandClassBase
         {
             foreach (ConstructorInfo ctr in typeof(T).GetTypeInfo().DeclaredConstructors)
             {
@@ -93,6 +122,25 @@ namespace ZWave.CommandClasses
         {
             base.HandleEvent(command);
 
+            if (command.Payload.Length < 4)
+                throw new ReponseFormatException($"The response was not in the expected format. {GetType().Name}: Payload: {BitConverter.ToString(command.Payload)}");
+
+            byte endPointId = command.Payload[0];
+            CommandClass commandClass = (CommandClass)command.Payload[2];
+            lock(_endpointCommandClasses)
+            {
+                if (_endpointCommandClasses.ContainsKey(endPointId))
+                {
+                    EndpointSupportedCommandClassBase endpointCommandClass = _endpointCommandClasses[endPointId].Values.FirstOrDefault(cc => cc.Class == commandClass);
+                    if (endpointCommandClass != null)
+                    {
+                        endpointCommandClass.HandleEndpointReport(command.Payload.Skip(4).ToArray(), command.Payload[3]);
+                    }
+                }
+            }
+
+            // This part is for backward compatibility.
+            //
             var report = new MultiChannelReport(Node, command.Payload);
             OnChanged(new ReportEventArgs<MultiChannelReport>(report));
         }

--- a/ZWave/CommandClasses/MultiChannelAssociation.cs
+++ b/ZWave/CommandClasses/MultiChannelAssociation.cs
@@ -1,0 +1,68 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using ZWave.Channel;
+
+namespace ZWave.CommandClasses
+{
+    public class MultiChannelAssociation : CommandClassBase
+    {
+        public class Endpoint
+        {
+            public byte NodeId { get; }
+
+            public byte EndpointId { get; }
+
+            public Endpoint(byte nodeId, byte endpointId)
+            {
+                NodeId = nodeId;
+                EndpointId = endpointId;
+            }
+        }
+
+        private const byte MultiChannelAssociationSetMarker = 0;
+        private const byte MultiChannelAssociationRemoveMarker = 0;
+
+        enum command
+        {
+            Set = 0x01,
+            Get = 0x02,
+            Report = 0x03,
+            Remove = 0x04,
+            GroupingsGet = 0x05,
+            GroupingsReport = 0x06
+        }
+
+        public MultiChannelAssociation(Node node)
+            : base(node, CommandClass.MultiChannelAssociation)
+        { }
+
+        public Task Add(byte groupId, byte[] destinationNodeIds, Endpoint[] destinationEndpoints)
+        {
+            return Channel.Send(Node, new Command(Class, command.Set, GetEndpointsPayload(groupId, destinationNodeIds, destinationEndpoints, MultiChannelAssociationSetMarker)));
+        }
+
+        public async Task<MultiChannelAssociationReport> Get(byte groupID)
+        {
+            byte[] response = await Channel.Send(Node, new Command(Class, command.Get, groupID), command.Report);
+            return new MultiChannelAssociationReport(Node, response);
+        }
+
+        public Task Remove(byte groupId, byte[] destinationNodeIds, Endpoint[] destinationEndpoints)
+        {
+            return Channel.Send(Node, new Command(Class, command.Remove, GetEndpointsPayload(groupId, destinationNodeIds, destinationEndpoints, MultiChannelAssociationRemoveMarker)));
+        }
+
+        public async Task<AssociationGroupsReport> GetGroups()
+        {
+            var response = await Channel.Send(Node, new Command(Class, command.GroupingsGet), command.GroupingsReport);
+            return new AssociationGroupsReport(Node, response);
+        }
+
+        private static byte[] GetEndpointsPayload(byte groupId, byte[] destinationNodeIds, Endpoint[] destinationEndpoints, byte marker)
+        {
+            IEnumerable<byte> endpointsPayload = destinationEndpoints.SelectMany(e => new byte[] { e.NodeId, e.EndpointId });
+            return new byte[] { groupId }.Concat(destinationNodeIds).Concat(new byte[] { marker }).Concat(endpointsPayload).ToArray();
+        }
+    }
+}

--- a/ZWave/CommandClasses/MultiChannelAssociationReport.cs
+++ b/ZWave/CommandClasses/MultiChannelAssociationReport.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Linq;
+using ZWave.Channel.Protocol;
+
+namespace ZWave.CommandClasses
+{
+    public class MultiChannelAssociationReport : NodeReport
+    {
+        private const byte MultiChannelAssociationReportMarker = 0;
+
+        public byte GroupID { get; }
+
+        public byte MaxNodesSupported { get; }
+
+        public byte ReportsToFollow { get; }
+
+        public byte[] Nodes { get; }
+
+        public MultiChannelAssociation.Endpoint[] Endpoints { get; }
+
+        internal MultiChannelAssociationReport(Node node, byte[] payload) : base(node)
+        {
+            if (payload == null)
+                throw new ArgumentNullException(nameof(payload));
+            if (payload.Length < 3)
+                throw new ReponseFormatException($"The response was not in the expected format. {GetType().Name}: Payload: {BitConverter.ToString(payload)}");
+
+            GroupID = payload[0];
+            MaxNodesSupported = payload[1];
+            ReportsToFollow = payload[2];
+            Nodes = payload.Skip(3).TakeWhile(b => b != MultiChannelAssociationReportMarker).ToArray();
+            byte[] endpointsPayload = payload.Skip(3).SkipWhile(b => b != MultiChannelAssociationReportMarker).Skip(1).ToArray();
+            if (endpointsPayload.Length % 2 != 0)
+            {
+                throw new ReponseFormatException($"The response was not in the expected format. Wrong format of endpoints. {GetType().Name}: Payload: {BitConverter.ToString(payload)}");
+            }
+
+            Endpoints = new MultiChannelAssociation.Endpoint[endpointsPayload.Length / 2];
+            for (int i = 0, j = 0; i < Endpoints.Length; i++, j+=2)
+            {
+                Endpoints[i] = new MultiChannelAssociation.Endpoint(endpointsPayload[j], endpointsPayload[j + 1]);
+            }
+        }
+    }
+}

--- a/ZWave/Devices/Fibaro/MultiSwitch.cs
+++ b/ZWave/Devices/Fibaro/MultiSwitch.cs
@@ -17,37 +17,32 @@ namespace ZWave.Devices.Fibaro
         public MultiSwitch(Node node)
             : base(node)
         {
-            Node.GetCommandClass<MultiChannel>().Changed += Switch_Changed;
+            MultiChannel multiChannel = Node.GetCommandClass<MultiChannel>();
+            multiChannel.GetEndPointCommandClass<SwitchBinary>(1).Changed += Switch1Changed;
+            multiChannel.GetEndPointCommandClass<SwitchBinary>(2).Changed += Switch2Changed;
         }
 
-        private void Switch_Changed(object sender, ReportEventArgs<MultiChannelReport> e)
+        private void Switch1Changed(object sender, ReportEventArgs<SwitchBinaryReport> e)
         {
-            var endpointReport = (SwitchBinaryReport) e.Report.Report;
-            switch (e.Report.EndPointID)
+            if (e.Report.Value)
             {
-                case 1:
-                    if (endpointReport.Value)
-                    {
-                        OnSwitchedOn1(EventArgs.Empty);
-                    }
-                    else
-                    {
-                        OnSwitchedOff1(EventArgs.Empty);
-                    }
-                    break;
-                case 2:
-                    if (endpointReport.Value)
-                    {
-                        OnSwitchedOn2(EventArgs.Empty);
-                    }
-                    else
-                    {
-                        OnSwitchedOff2(EventArgs.Empty);
-                    }
-                    break;
-                default:
-                    //don't care: this device only ever has 2 endpoints.
-                    break;
+                OnSwitchedOn1(EventArgs.Empty);
+            }
+            else
+            {
+                OnSwitchedOff1(EventArgs.Empty);
+            }
+        }
+
+        private void Switch2Changed(object sender, ReportEventArgs<SwitchBinaryReport> e)
+        {
+            if (e.Report.Value)
+            {
+                OnSwitchedOn2(EventArgs.Empty);
+            }
+            else
+            {
+                OnSwitchedOff2(EventArgs.Empty);
             }
         }
 

--- a/ZWave/Node.cs
+++ b/ZWave/Node.cs
@@ -45,6 +45,7 @@ namespace ZWave
             _commandClasses.Add(new Clock(this));
             _commandClasses.Add(new CentralScene(this));
             _commandClasses.Add(new SceneActivation(this));
+            _commandClasses.Add(new MultiChannelAssociation(this));
         }
 
         private static byte GetNextFunctionID()

--- a/ZWave/ZWave.projitems
+++ b/ZWave/ZWave.projitems
@@ -46,6 +46,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)CommandClasses\AssociationGroupsReport.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CommandClasses\AssociationReport.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CommandClasses\EndpointSupportedCommandClassBase.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)CommandClasses\MultiChannelAssociation.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)CommandClasses\MultiChannelAssociationReport.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CommandClasses\MultiChannelCapabilityReport.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CommandClasses\MultiChannelEndPointReport.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CommandClasses\SensorMultilevelSupportedSensorReport.cs" />


### PR DESCRIPTION
Improve multi channel support by:
* Adding multi channel association command class
* Add support for getting events in the endpoint command classes supplied by the multi channel command class
* Improved the message filtering of the multi channel commands to filter also by endpoint id and encapsulated response command type
