### PR TITLE
Adding cancellation token support

### DIFF
--- a/ZWave/Channel/Extentions.cs
+++ b/ZWave/Channel/Extentions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace ZWave.Channel
@@ -7,21 +8,42 @@ namespace ZWave.Channel
     {
         public static Task<byte[]> Send(this ZWaveChannel channel, byte nodeID, Command command, Enum responseCommand)
         {
-            return channel.Send(nodeID, command, Convert.ToByte(responseCommand));
+            return channel.Send(nodeID, command, Convert.ToByte(responseCommand), CancellationToken.None);
         }
+
+        public static Task<byte[]> Send(this ZWaveChannel channel, byte nodeID, Command command, Enum responseCommand, CancellationToken cancellationToken)
+        {
+            return channel.Send(nodeID, command, Convert.ToByte(responseCommand), cancellationToken);
+        }
+
         public static Task Send(this ZWaveChannel channel, Node node, Command command)
         {
-            return channel.Send(node.NodeID, command);
+            return channel.Send(node.NodeID, command, CancellationToken.None);
+        }
+
+        public static Task Send(this ZWaveChannel channel, Node node, Command command, CancellationToken cancellationToken)
+        {
+            return channel.Send(node.NodeID, command, cancellationToken);
         }
 
         public static Task<byte[]> Send(this ZWaveChannel channel, Node node, Command command, Enum responseCommand)
         {
-            return channel.Send(node.NodeID, command, Convert.ToByte(responseCommand));
+            return channel.Send(node.NodeID, command, Convert.ToByte(responseCommand), CancellationToken.None);
+        }
+
+        public static Task<byte[]> Send(this ZWaveChannel channel, Node node, Command command, Enum responseCommand, CancellationToken cancellationToken)
+        {
+            return channel.Send(node.NodeID, command, Convert.ToByte(responseCommand), cancellationToken);
         }
 
         public static Task<byte[]> Send(this ZWaveChannel channel, Node node, Command command, Enum responseCommand, Func<byte[], bool> payloadValidation)
         {
-            return channel.Send(node.NodeID, command, Convert.ToByte(responseCommand), payloadValidation);
+            return channel.Send(node.NodeID, command, Convert.ToByte(responseCommand), payloadValidation, CancellationToken.None);
+        }
+
+        public static Task<byte[]> Send(this ZWaveChannel channel, Node node, Command command, Enum responseCommand, Func<byte[], bool> payloadValidation, CancellationToken cancellationToken)
+        {
+            return channel.Send(node.NodeID, command, Convert.ToByte(responseCommand), payloadValidation, cancellationToken);
         }
     }
 }

--- a/ZWave/CommandClasses/Alarm.cs
+++ b/ZWave/CommandClasses/Alarm.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using ZWave.Channel;
 
@@ -22,9 +23,14 @@ namespace ZWave.CommandClasses
         {
         }
 
-        public async Task<AlarmReport> Get()
+        public Task<AlarmReport> Get()
         {
-            var response = await Channel.Send(Node, new Command(Class, command.Get), command.Report);
+            return Get(CancellationToken.None);
+        }
+
+        public async Task<AlarmReport> Get(CancellationToken cancellationToken)
+        {
+            var response = await Channel.Send(Node, new Command(Class, command.Get), command.Report, cancellationToken);
             return new AlarmReport(Node, response);
         }
 

--- a/ZWave/CommandClasses/Association.cs
+++ b/ZWave/CommandClasses/Association.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
 using ZWave.Channel;
+using System.Threading;
 
 namespace ZWave.CommandClasses
 {
@@ -23,27 +24,47 @@ namespace ZWave.CommandClasses
         {
         }
 
-        public async Task<AssociationReport> Get(byte groupID)
+        public Task<AssociationReport> Get(byte groupID)
         {
-            var response = await Channel.Send(Node, new Command(Class, command.Get, groupID), command.Report);
+            return Get(groupID, CancellationToken.None);
+        }
+
+        public async Task<AssociationReport> Get(byte groupID, CancellationToken cancellationToken)
+        {
+            var response = await Channel.Send(Node, new Command(Class, command.Get, groupID), command.Report, cancellationToken);
             return new AssociationReport(Node, response);
         }
 
-        public async Task Add(byte groupID, params byte[] nodes)
+        public Task Add(byte groupID, params byte[] nodes)
         {
-            var payload = new byte[] { groupID }.Concat(nodes).ToArray();
-            await Channel.Send(Node, new Command(Class, command.Set, payload));
+            return Add(groupID, CancellationToken.None, nodes);
         }
 
-        public async Task Remove(byte groupID, params byte[] nodes)
+        public async Task Add(byte groupID, CancellationToken cancellationToken, params byte[] nodes)
         {
             var payload = new byte[] { groupID }.Concat(nodes).ToArray();
-            await Channel.Send(Node, new Command(Class, command.Remove, payload));
+            await Channel.Send(Node, new Command(Class, command.Set, payload), cancellationToken);
         }
 
-        public async Task<AssociationGroupsReport> GetGroups()
+        public Task Remove(byte groupID, params byte[] nodes)
         {
-            var response = await Channel.Send(Node, new Command(Class, command.GroupingsGet), command.GroupingsReport);
+            return Remove(groupID, CancellationToken.None, nodes);
+        }
+
+        public async Task Remove(byte groupID, CancellationToken cancellationToken, params byte[] nodes)
+        {
+            var payload = new byte[] { groupID }.Concat(nodes).ToArray();
+            await Channel.Send(Node, new Command(Class, command.Remove, payload), cancellationToken);
+        }
+
+        public Task<AssociationGroupsReport> GetGroups()
+        {
+            return GetGroups(CancellationToken.None);
+        }
+
+        public async Task<AssociationGroupsReport> GetGroups(CancellationToken cancellationToken)
+        {
+            var response = await Channel.Send(Node, new Command(Class, command.GroupingsGet), command.GroupingsReport, cancellationToken);
             return new AssociationGroupsReport(Node, response);
         }
     }

--- a/ZWave/CommandClasses/Basic.cs
+++ b/ZWave/CommandClasses/Basic.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using ZWave.Channel;
 
@@ -21,15 +22,25 @@ namespace ZWave.CommandClasses
         {
         }
 
-        public async Task<BasicReport> Get()
+        public Task<BasicReport> Get()
         {
-            var response = await Channel.Send(Node, new Command(Class, command.Get), command.Report);
+            return Get(CancellationToken.None);
+        }
+
+        public async Task<BasicReport> Get(CancellationToken cancellationToken)
+        {
+            var response = await Channel.Send(Node, new Command(Class, command.Get), command.Report, cancellationToken);
             return new BasicReport(Node, response);
         }
 
-        public async Task Set(byte value)
+        public Task Set(byte value)
         {
-            await Channel.Send(Node, new Command(Class, command.Set, value));
+            return Set(value, CancellationToken.None);
+        }
+
+        public async Task Set(byte value, CancellationToken cancellationToken)
+        {
+            await Channel.Send(Node, new Command(Class, command.Set, value), cancellationToken);
         }
 
         protected internal override void HandleEvent(Command command)

--- a/ZWave/CommandClasses/Battery.cs
+++ b/ZWave/CommandClasses/Battery.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using ZWave.Channel;
 
@@ -20,9 +21,14 @@ namespace ZWave.CommandClasses
         {
         }
 
-        public async Task<BatteryReport> Get()
+        public Task<BatteryReport> Get()
         {
-            var response = await Channel.Send(Node, new Command(Class, command.Get), command.Report);
+            return Get(CancellationToken.None);
+        }
+
+        public async Task<BatteryReport> Get(CancellationToken cancellationToken)
+        {
+            var response = await Channel.Send(Node, new Command(Class, command.Get), command.Report, cancellationToken);
             return new BatteryReport(Node, response);
         }
 

--- a/ZWave/CommandClasses/Clock.cs
+++ b/ZWave/CommandClasses/Clock.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using ZWave.Channel;
 
@@ -19,13 +20,23 @@ namespace ZWave.CommandClasses
         {
         }
 
-        public async Task<ClockReport> Get()
+        public Task<ClockReport> Get()
         {
-            var response = await Channel.Send(Node, new Command(Class, command.Get), command.Report);
+            return Get(CancellationToken.None);
+        }
+
+        public async Task<ClockReport> Get(CancellationToken cancellationToken)
+        {
+            var response = await Channel.Send(Node, new Command(Class, command.Get), command.Report, cancellationToken);
             return new ClockReport(Node, response);
         }
 
-        public async Task Set(DayOfWeek dayOfWeek, byte hour, byte minute)
+        public Task Set(DayOfWeek dayOfWeek, byte hour, byte minute)
+        {
+            return Set(dayOfWeek, hour, minute);
+        }
+
+        public async Task Set(DayOfWeek dayOfWeek, byte hour, byte minute, CancellationToken cancellationToken)
         {
             var day = default(byte);
             switch (dayOfWeek)
@@ -58,7 +69,7 @@ namespace ZWave.CommandClasses
             payload[0] |= (byte)(hour & 0x1F);
             payload[1] = minute;
 
-            await Channel.Send(Node, new Command(Class, command.Set, payload));
+            await Channel.Send(Node, new Command(Class, command.Set, payload), cancellationToken);
         }
     }
 }

--- a/ZWave/CommandClasses/Color.cs
+++ b/ZWave/CommandClasses/Color.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
 using ZWave.Channel;
+using System.Threading;
 
 namespace ZWave.CommandClasses
 {
@@ -20,17 +21,27 @@ namespace ZWave.CommandClasses
         {
         }
 
-        public async Task Set(ColorComponent[] components)
+        public Task Set(ColorComponent[] components)
+        {
+            return Set(components, CancellationToken.None);
+        }
+
+        public async Task Set(ColorComponent[] components, CancellationToken cancellationToken)
         {
             var payload = new List<byte>();
             payload.Add((byte)components.Length);
             payload.AddRange(components.SelectMany(element => element.ToBytes()));
-            await Channel.Send(Node, new Command(Class, command.Set, payload.ToArray()));
+            await Channel.Send(Node, new Command(Class, command.Set, payload.ToArray()), cancellationToken);
         }
 
-        public async Task<ColorReport> Get(byte componentID)
+        public Task<ColorReport> Get(byte componentID)
         {
-            var response = await Channel.Send(Node, new Command(Class, command.Get, componentID), command.Report);
+            return Get(componentID, CancellationToken.None);
+        }
+
+        public async Task<ColorReport> Get(byte componentID, CancellationToken cancellationToken)
+        {
+            var response = await Channel.Send(Node, new Command(Class, command.Get, componentID), command.Report, cancellationToken);
             return new ColorReport(Node, response);
         }
     }

--- a/ZWave/CommandClasses/Configuration.cs
+++ b/ZWave/CommandClasses/Configuration.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using ZWave.Channel;
 
@@ -20,64 +21,114 @@ namespace ZWave.CommandClasses
         {
         }
 
-        public async Task<ConfigurationReport> Get(byte parameter)
+        public Task<ConfigurationReport> Get(byte parameter)
         {
-            var response = await Channel.Send(Node, new Command(Class, command.Get, parameter), command.Report);
+            return Get(parameter, CancellationToken.None);
+        }
+
+        public async Task<ConfigurationReport> Get(byte parameter, CancellationToken cancellationToken)
+        {
+            var response = await Channel.Send(Node, new Command(Class, command.Get, parameter), command.Report, cancellationToken);
             return new ConfigurationReport(Node, response);
         }
 
-        public async Task Set(byte parameter, object value, byte size)
+        public Task Set(byte parameter, object value, byte size)
+        {
+            return Set(parameter, value, size, CancellationToken.None);
+        }
+
+        public async Task Set(byte parameter, object value, byte size, CancellationToken cancellationToken)
         {
             var int64 = Convert.ToInt64(value);
-            await Set(parameter, int64, true, size);
+            await Set(parameter, int64, true, size, cancellationToken);
         }
 
-        public async Task Set(byte parameter, sbyte value)
+        public Task Set(byte parameter, sbyte value)
         {
-            await Set(parameter, value, true);
+            return Set(parameter, value, CancellationToken.None);
         }
 
-        public async Task Set(byte parameter, byte value)
+        public async Task Set(byte parameter, sbyte value, CancellationToken cancellationToken)
         {
-            await Set(parameter, value, false);
+            await Set(parameter, value, true, 0, cancellationToken);
         }
 
-        public async Task Set(byte parameter, short value)
+        public Task Set(byte parameter, byte value)
         {
-            await Set(parameter, value, true);
+            return Set(parameter, value, CancellationToken.None);
         }
 
-        public async Task Set(byte parameter, ushort value)
+        public async Task Set(byte parameter, byte value, CancellationToken cancellationToken)
         {
-            await Set(parameter, value, false);
+            await Set(parameter, value, false, 0, cancellationToken);
         }
 
-        public async Task Set(byte parameter, int value)
+        public Task Set(byte parameter, short value)
         {
-            await Set(parameter, value, true);
+            return Set(parameter, value, CancellationToken.None);
         }
 
-        public async Task Set(byte parameter, uint value)
+        public async Task Set(byte parameter, short value, CancellationToken cancellationToken)
         {
-            await Set(parameter, value, false);
+            await Set(parameter, value, true, 0, cancellationToken);
         }
 
-        public async Task Set(byte parameter, long value)
+        public Task Set(byte parameter, ushort value)
         {
-            await Set(parameter, value, true);
+            return Set(parameter, value, CancellationToken.None);
         }
 
-        public async Task Set(byte parameter, ulong value)
+        public async Task Set(byte parameter, ushort value, CancellationToken cancellationToken)
         {
-            await Set(parameter, (long)value, false);
+            await Set(parameter, value, false, 0, cancellationToken);
         }
 
-        private async Task Set(byte parameter, long value, bool signed, byte size = 0)
+        public Task Set(byte parameter, int value)
+        {
+            return Set(parameter, value, CancellationToken.None);
+        }
+
+        public async Task Set(byte parameter, int value, CancellationToken cancellationToken)
+        {
+            await Set(parameter, value, true, 0, cancellationToken);
+        }
+
+        public Task Set(byte parameter, uint value)
+        {
+            return Set(parameter, value, CancellationToken.None);
+        }
+
+        public async Task Set(byte parameter, uint value, CancellationToken cancellationToken)
+        {
+            await Set(parameter, value, false, 0, cancellationToken);
+        }
+
+        public Task Set(byte parameter, long value)
+        {
+            return Set(parameter, value, CancellationToken.None);
+        }
+
+        public async Task Set(byte parameter, long value, CancellationToken cancellationToken)
+        {
+            await Set(parameter, value, true, 0, cancellationToken);
+        }
+
+        public Task Set(byte parameter, ulong value)
+        {
+            return Set(parameter, value, CancellationToken.None);
+        }
+
+        public async Task Set(byte parameter, ulong value, CancellationToken cancellationToken)
+        {
+            await Set(parameter, (long)value, false, 0, cancellationToken);
+        }
+
+        private async Task Set(byte parameter, long value, bool signed, byte size, CancellationToken cancellationToken)
         {
             if (size == 0)
             {
                 // extra roundtrip to get the correct size of the parameter
-                var response = await Channel.Send(Node, new Command(Class, command.Get, parameter), command.Report);
+                var response = await Channel.Send(Node, new Command(Class, command.Get, parameter), command.Report, cancellationToken);
                 size = response[1];
             }
 
@@ -99,7 +150,7 @@ namespace ZWave.CommandClasses
                 default:
                     throw new NotSupportedException($"Size:{size} is not supported");
             }
-            await Channel.Send(Node, new Command(Class, command.Set, new[] { parameter, (byte)values.Length }.Concat(values).ToArray()));
+            await Channel.Send(Node, new Command(Class, command.Set, new[] { parameter, (byte)values.Length }.Concat(values).ToArray()), cancellationToken);
         }
     }
 }

--- a/ZWave/CommandClasses/EndpointSupportedCommandClassBase.cs
+++ b/ZWave/CommandClasses/EndpointSupportedCommandClassBase.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using ZWave.Channel;
 using ZWave.Channel.Protocol;
@@ -26,34 +27,34 @@ namespace ZWave.CommandClasses
             _endpointId = endpointId;
         }
 
-        protected async Task<byte[]> Send(Command command, Enum responseCommand)
+        protected async Task<byte[]> Send(Command command, Enum responseCommand, CancellationToken cancellationToken)
         {
             if (_endpointId == 0)
             {
                 // Send in regular manner.
                 //
-                return await Channel.Send(Node, command, responseCommand);
+                return await Channel.Send(Node, command, responseCommand, cancellationToken);
             }
             else
             {
                 Command encapsolatedCommand = await EncapsulatCommandForEndpoint(command);
-                byte[] response = await Channel.Send(Node, encapsolatedCommand, MultiChannel.command.Encap, EncapsulatCommandEndpointValidator(responseCommand));
+                byte[] response = await Channel.Send(Node, encapsolatedCommand, MultiChannel.command.Encap, EncapsulatCommandEndpointValidator(responseCommand), cancellationToken);
                 return ExtractEndpointResponse(response, responseCommand);
             }
         }
 
-        protected async Task Send(Command command)
+        protected async Task Send(Command command, CancellationToken cancellationToken)
         {
             if (_endpointId == 0)
             {
                 // Send in regular manner.
                 //
-                await Channel.Send(Node, command);
+                await Channel.Send(Node, command, cancellationToken);
             }
             else
             {
                 Command encapsolatedCommand = await EncapsulatCommandForEndpoint(command);
-                await Channel.Send(Node, encapsolatedCommand);
+                await Channel.Send(Node, encapsolatedCommand, cancellationToken);
             }
         }
 

--- a/ZWave/CommandClasses/ManufacturerSpecific.cs
+++ b/ZWave/CommandClasses/ManufacturerSpecific.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using ZWave.Channel;
 
@@ -18,9 +19,14 @@ namespace ZWave.CommandClasses
         {
         }
 
-        public async Task<ManufacturerSpecificReport> Get()
+        public Task<ManufacturerSpecificReport> Get()
         {
-            var response = await Channel.Send(Node, new Command(Class, command.Get), command.Report);
+            return Get(CancellationToken.None);
+        }
+
+        public async Task<ManufacturerSpecificReport> Get(CancellationToken cancellationToken)
+        {
+            var response = await Channel.Send(Node, new Command(Class, command.Get), command.Report, cancellationToken);
             return new ManufacturerSpecificReport(Node, response);
         }
     }

--- a/ZWave/CommandClasses/Meter.cs
+++ b/ZWave/CommandClasses/Meter.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using ZWave.Channel;
 
@@ -25,15 +26,25 @@ namespace ZWave.CommandClasses
         {
         }
 
-        public async Task<MeterReport> Get()
+        public Task<MeterReport> Get()
         {
-            var response = await Channel.Send(Node, new Command(Class, command.Get), command.Report);
+            return Get(CancellationToken.None);
+        }
+
+        public async Task<MeterReport> Get(CancellationToken cancellationToken)
+        {
+            var response = await Channel.Send(Node, new Command(Class, command.Get), command.Report, cancellationToken);
             return new MeterReport(Node, response);
         }
 
-        public async Task<MeterSupportedReport> GetSupported()
+        public Task<MeterSupportedReport> GetSupported()
         {
-            var response = await Channel.Send(Node, new Command(Class, command.SupportedGet), command.SupportedReport);
+            return GetSupported(CancellationToken.None);
+        }
+
+        public async Task<MeterSupportedReport> GetSupported(CancellationToken cancellationToken)
+        {
+            var response = await Channel.Send(Node, new Command(Class, command.SupportedGet), command.SupportedReport, cancellationToken);
             return new MeterSupportedReport(Node, response);
         }
 

--- a/ZWave/CommandClasses/MultiChannelAssociation.cs
+++ b/ZWave/CommandClasses/MultiChannelAssociation.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using ZWave.Channel;
 
@@ -39,23 +40,43 @@ namespace ZWave.CommandClasses
 
         public Task Add(byte groupId, byte[] destinationNodeIds, Endpoint[] destinationEndpoints)
         {
-            return Channel.Send(Node, new Command(Class, command.Set, GetEndpointsPayload(groupId, destinationNodeIds, destinationEndpoints, MultiChannelAssociationSetMarker)));
+            return Add(groupId, destinationNodeIds, destinationEndpoints, CancellationToken.None);
         }
 
-        public async Task<MultiChannelAssociationReport> Get(byte groupID)
+        public Task Add(byte groupId, byte[] destinationNodeIds, Endpoint[] destinationEndpoints, CancellationToken cancellationToken)
         {
-            byte[] response = await Channel.Send(Node, new Command(Class, command.Get, groupID), command.Report);
+            return Channel.Send(Node, new Command(Class, command.Set, GetEndpointsPayload(groupId, destinationNodeIds, destinationEndpoints, MultiChannelAssociationSetMarker)), cancellationToken);
+        }
+
+        public Task<MultiChannelAssociationReport> Get(byte groupdId)
+        {
+            return Get(groupdId, CancellationToken.None);
+        }
+
+        public async Task<MultiChannelAssociationReport> Get(byte groupId, CancellationToken cancellationToken)
+        {
+            byte[] response = await Channel.Send(Node, new Command(Class, command.Get, groupId), command.Report, cancellationToken);
             return new MultiChannelAssociationReport(Node, response);
         }
 
         public Task Remove(byte groupId, byte[] destinationNodeIds, Endpoint[] destinationEndpoints)
         {
-            return Channel.Send(Node, new Command(Class, command.Remove, GetEndpointsPayload(groupId, destinationNodeIds, destinationEndpoints, MultiChannelAssociationRemoveMarker)));
+            return Remove(groupId, destinationNodeIds, destinationEndpoints, CancellationToken.None);
         }
 
-        public async Task<AssociationGroupsReport> GetGroups()
+        public Task Remove(byte groupId, byte[] destinationNodeIds, Endpoint[] destinationEndpoints, CancellationToken cancellationToken)
         {
-            var response = await Channel.Send(Node, new Command(Class, command.GroupingsGet), command.GroupingsReport);
+            return Channel.Send(Node, new Command(Class, command.Remove, GetEndpointsPayload(groupId, destinationNodeIds, destinationEndpoints, MultiChannelAssociationRemoveMarker)), cancellationToken);
+        }
+
+        public Task<AssociationGroupsReport> GetGroups()
+        {
+            return GetGroups(CancellationToken.None);
+        }
+
+        public async Task<AssociationGroupsReport> GetGroups(CancellationToken cancellationToken)
+        {
+            var response = await Channel.Send(Node, new Command(Class, command.GroupingsGet), command.GroupingsReport, cancellationToken);
             return new AssociationGroupsReport(Node, response);
         }
 

--- a/ZWave/CommandClasses/SensorAlarm.cs
+++ b/ZWave/CommandClasses/SensorAlarm.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using ZWave.Channel;
 
@@ -22,9 +23,14 @@ namespace ZWave.CommandClasses
         {
         }
 
-        public async Task<SensorAlarmReport> Get(AlarmType type)
+        public Task<SensorAlarmReport> Get(AlarmType type)
         {
-            var response = await Channel.Send(Node, new Command(Class, command.Get, Convert.ToByte(type)), command.Report);
+            return Get(type, CancellationToken.None);
+        }
+
+        public async Task<SensorAlarmReport> Get(AlarmType type, CancellationToken cancellationToken)
+        {
+            var response = await Channel.Send(Node, new Command(Class, command.Get, Convert.ToByte(type)), command.Report, cancellationToken);
             return new SensorAlarmReport(Node, response);
         }
 

--- a/ZWave/CommandClasses/SensorBinary.cs
+++ b/ZWave/CommandClasses/SensorBinary.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using ZWave.Channel;
 
@@ -24,9 +25,14 @@ namespace ZWave.CommandClasses
             : base(node, CommandClass.SensorBinary, endpointId)
         { }
 
-        public async Task<SensorBinaryReport> Get()
+        public Task<SensorBinaryReport> Get()
         {
-            var response = await Send(new Command(Class, command.Get), command.Report);
+            return Get(CancellationToken.None);
+        }
+
+        public async Task<SensorBinaryReport> Get(CancellationToken cancellationToken)
+        {
+            var response = await Send(new Command(Class, command.Get), command.Report, cancellationToken);
             return new SensorBinaryReport(Node, response);
         }
 

--- a/ZWave/CommandClasses/SensorMultiLevel.cs
+++ b/ZWave/CommandClasses/SensorMultiLevel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using ZWave.Channel;
 
@@ -34,20 +35,30 @@ namespace ZWave.CommandClasses
             return report.Version >= GetSupportedSensorsMinimalProtocolVersion;
         }
 
-        public async Task<SensorMultilevelSupportedSensorReport> GetSupportedSensors()
+        public Task<SensorMultilevelSupportedSensorReport> GetSupportedSensors()
+        {
+            return GetSupportedSensors(CancellationToken.None);
+        }
+
+        public async Task<SensorMultilevelSupportedSensorReport> GetSupportedSensors(CancellationToken cancellationToken)
         {
             if (!await IsSupportGetSupportedSensors())
             {
                 throw new VersionNotSupportedException($"GetSupportedSensors works with class type {Class} greater or equal to {GetSupportedSensorsMinimalProtocolVersion}.");
             }
 
-            var response = await Send(new Command(Class, command.SupportedGet), command.SupportedReport);
+            var response = await Send(new Command(Class, command.SupportedGet), command.SupportedReport, cancellationToken);
             return new SensorMultilevelSupportedSensorReport(Node, response);
         }
 
-        public async Task<SensorMultiLevelReport> Get(SensorType type)
+        public Task<SensorMultiLevelReport> Get(SensorType type)
         {
-            var response = await Send(new Command(Class, command.Get, (byte)type), command.Report);
+            return Get(type, CancellationToken.None);
+        }
+
+        public async Task<SensorMultiLevelReport> Get(SensorType type, CancellationToken cancellationToken)
+        {
+            var response = await Send(new Command(Class, command.Get, (byte)type), command.Report, cancellationToken);
             return new SensorMultiLevelReport(Node, response);
         }
 

--- a/ZWave/CommandClasses/SwitchBinary.cs
+++ b/ZWave/CommandClasses/SwitchBinary.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using ZWave.Channel;
 
@@ -23,15 +24,25 @@ namespace ZWave.CommandClasses
             : base(node, CommandClass.SwitchBinary, endpointId)
         { }
 
-        public async Task<SwitchBinaryReport> Get()
+        public Task<SwitchBinaryReport> Get()
         {
-            var response = await Send(new Command(Class, command.Get), command.Report);
+            return Get(CancellationToken.None);
+        }
+
+        public async Task<SwitchBinaryReport> Get(CancellationToken cancellationToken)
+        {
+            var response = await Send(new Command(Class, command.Get), command.Report, cancellationToken);
             return new SwitchBinaryReport(Node, response);
         }
 
-        public async Task Set(bool value)
+        public Task Set(bool value)
         {
-            await Send(new Command(Class, command.Set, value ? (byte)0xFF : (byte)0x00));
+            return Set(value, CancellationToken.None);
+        }
+
+        public async Task Set(bool value, CancellationToken cancellationToken)
+        {
+            await Send(new Command(Class, command.Set, value ? (byte)0xFF : (byte)0x00), cancellationToken);
         }
 
         protected internal override void HandleEvent(Command command)

--- a/ZWave/CommandClasses/SwitchMultiLevel.cs
+++ b/ZWave/CommandClasses/SwitchMultiLevel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using ZWave.Channel;
 
@@ -25,18 +26,29 @@ namespace ZWave.CommandClasses
             : base(node, CommandClass.SwitchMultiLevel, endpointId)
         { }
 
-        public async Task<SwitchMultiLevelReport> Get()
+        public Task<SwitchMultiLevelReport> Get()
         {
-            var response = await Send(new Command(Class, command.Get), command.Report);
+            return Get(CancellationToken.None);
+        }
+
+
+        public async Task<SwitchMultiLevelReport> Get(CancellationToken cancellationToken)
+        {
+            var response = await Send(new Command(Class, command.Get), command.Report, cancellationToken);
             return new SwitchMultiLevelReport(Node, response);
         }
 
-		public async Task Set(byte value)
-		{
-			await Channel.Send(Node, new Command(Class, command.Set, value));
-		}
+        public Task Set(byte value)
+        {
+            return Set(value, CancellationToken.None);
+        }
 
-		protected internal override void HandleEvent(Command command)
+        public async Task Set(byte value, CancellationToken cancellationToken)
+        {
+            await Channel.Send(Node, new Command(Class, command.Set, value), cancellationToken);
+        }
+
+        protected internal override void HandleEvent(Command command)
         {
             base.HandleEvent(command);
 

--- a/ZWave/CommandClasses/ThermostatSetpoint.cs
+++ b/ZWave/CommandClasses/ThermostatSetpoint.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
 using ZWave.Channel;
+using System.Threading;
 
 namespace ZWave.CommandClasses
 {
@@ -23,19 +24,29 @@ namespace ZWave.CommandClasses
         {
         }
 
-        public async Task<ThermostatSetpointReport> Get(ThermostatSetpointType type)
+        public Task<ThermostatSetpointReport> Get(ThermostatSetpointType type)
         {
-            var response = await Channel.Send(Node, new Command(Class, command.Get, Convert.ToByte(type)), command.Report);
+            return Get(type, CancellationToken.None);
+        }
+
+        public async Task<ThermostatSetpointReport> Get(ThermostatSetpointType type, CancellationToken cancellationToken)
+        {
+            var response = await Channel.Send(Node, new Command(Class, command.Get, Convert.ToByte(type)), command.Report, cancellationToken);
             return new ThermostatSetpointReport(Node, response);
         }
 
-        public async Task Set(ThermostatSetpointType type, float value)
+        public Task Set(ThermostatSetpointType type, float value)
+        {
+            return Set(type, value, CancellationToken.None);
+        }
+
+        public async Task Set(ThermostatSetpointType type, float value, CancellationToken cancellationToken)
         {
             // encode value, decimals = 1, scale = 0 (°C) 
             var encoded = PayloadConverter.GetBytes(value, decimals: 1, scale: 0);
 
             var payload = new byte[] { Convert.ToByte(type) }.Concat(encoded).ToArray();
-            await Channel.Send(Node, new Command(Class, command.Set, payload));
+            await Channel.Send(Node, new Command(Class, command.Set, payload), cancellationToken);
         }
 
         protected internal override void HandleEvent(Command command)

--- a/ZWave/CommandClasses/Version.cs
+++ b/ZWave/CommandClasses/Version.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using ZWave.Channel;
 
@@ -21,15 +22,25 @@ namespace ZWave.CommandClasses
         {
         }
 
-        public async Task<VersionReport> Get()
+        public Task<VersionReport> Get()
         {
-            var response = await Channel.Send(Node, new Command(Class, command.Get), command.Report);
+            return Get(CancellationToken.None);
+        }
+
+        public async Task<VersionReport> Get(CancellationToken cancellationToken)
+        {
+            var response = await Channel.Send(Node, new Command(Class, command.Get), command.Report, cancellationToken);
             return new VersionReport(Node, response);
         }
 
-        public async Task<VersionCommandClassReport> GetCommandClass(CommandClass @class)
+        public Task<VersionCommandClassReport> GetCommandClass(CommandClass @class)
         {
-            var response = await Channel.Send(Node, new Command(Class, command.CommandClassGet, Convert.ToByte(@class)), command.CommandClassReport);
+            return GetCommandClass(@class, CancellationToken.None);
+        }
+
+        public async Task<VersionCommandClassReport> GetCommandClass(CommandClass @class, CancellationToken cancellationToken)
+        {
+            var response = await Channel.Send(Node, new Command(Class, command.CommandClassGet, Convert.ToByte(@class)), command.CommandClassReport, cancellationToken);
             return new VersionCommandClassReport(Node, response);
         }
     }

--- a/ZWave/CommandClasses/WakeUp.cs
+++ b/ZWave/CommandClasses/WakeUp.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using ZWave.Channel;
 
@@ -23,21 +24,36 @@ namespace ZWave.CommandClasses
         {
         }
 
-        public async Task<WakeUpIntervalReport> GetInterval()
+        public Task<WakeUpIntervalReport> GetInterval()
         {
-            var response = await Channel.Send(Node, new Command(Class, command.IntervalGet), command.IntervalReport);
+            return GetInterval(CancellationToken.None);
+        }
+
+        public async Task<WakeUpIntervalReport> GetInterval(CancellationToken cancellationToken)
+        {
+            var response = await Channel.Send(Node, new Command(Class, command.IntervalGet), command.IntervalReport, cancellationToken);
             return new WakeUpIntervalReport(Node, response);
         }
 
-        public async Task SetInterval(TimeSpan interval, byte targetNodeID)
+        public Task SetInterval(TimeSpan interval, byte targetNodeID)
         {
-            var seconds = PayloadConverter.GetBytes((uint)interval.TotalSeconds);
-            await Channel.Send(Node, new Command(Class, command.IntervalSet, seconds[1], seconds[2], seconds[3], targetNodeID));
+            return SetInterval(interval, targetNodeID, CancellationToken.None);
         }
 
-        public async Task NoMoreInformation()
+        public async Task SetInterval(TimeSpan interval, byte targetNodeID, CancellationToken cancellationToken)
         {
-            await Channel.Send(Node, new Command(Class, command.NoMoreInformation));
+            var seconds = PayloadConverter.GetBytes((uint)interval.TotalSeconds);
+            await Channel.Send(Node, new Command(Class, command.IntervalSet, seconds[1], seconds[2], seconds[3], targetNodeID), cancellationToken);
+        }
+
+        public Task NoMoreInformation()
+        {
+            return NoMoreInformation(CancellationToken.None);
+        }
+
+        public async Task NoMoreInformation(CancellationToken cancellationToken)
+        {
+            await Channel.Send(Node, new Command(Class, command.NoMoreInformation), cancellationToken);
         }
 
         protected internal override void HandleEvent(Command command)

--- a/ZWave/ZWaveController.cs
+++ b/ZWave/ZWaveController.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using ZWave.Channel;
 
@@ -113,32 +114,47 @@ namespace ZWave
             Channel.Close();
         }
 
-        public async Task<string> GetVersion()
+        public Task<string> GetVersion()
+        {
+            return GetVersion(CancellationToken.None);
+        }
+
+        public async Task<string> GetVersion(CancellationToken cancellationToken)
         {
             if (_version == null)
             {
-                var response = await Channel.Send(Function.GetVersion);
+                var response = await Channel.Send(Function.GetVersion, cancellationToken);
                 var data = response.TakeWhile(element => element != 0).ToArray();
                 _version = Encoding.UTF8.GetString(data, 0, data.Length);
             }
             return _version;
         }
 
-        public async Task<uint> GetHomeID()
+        public Task<uint> GetHomeID()
+        {
+            return GetHomeID(CancellationToken.None);
+        }
+
+        public async Task<uint> GetHomeID(CancellationToken cancellationToken)
         {
             if (_homeID == null)
             {
-                var response = await Channel.Send(Function.MemoryGetId);
+                var response = await Channel.Send(Function.MemoryGetId, cancellationToken);
                 _homeID = PayloadConverter.ToUInt32(response);
             }
             return _homeID.Value;
         }
 
-        public async Task<byte> GetNodeID()
+        public Task<byte> GetNodeID()
+        {
+            return GetNodeID(CancellationToken.None);
+        }
+
+        public async Task<byte> GetNodeID(CancellationToken cancellationToken)
         {
             if (_nodeID == null)
             {
-                var response = await Channel.Send(Function.MemoryGetId);
+                var response = await Channel.Send(Function.MemoryGetId, cancellationToken);
                 _nodeID = response[4];
             }
             return _nodeID.Value;
@@ -146,9 +162,14 @@ namespace ZWave
 
         public Task<NodeCollection> DiscoverNodes()
         {
+            return DiscoverNodes(CancellationToken.None);
+        }
+
+        public Task<NodeCollection> DiscoverNodes(CancellationToken cancellationToken)
+        {
             return _getNodes = Task.Run(async () =>
             {
-                var response = await Channel.Send(Function.DiscoveryNodes);
+                var response = await Channel.Send(Function.DiscoveryNodes, cancellationToken);
                 var values = response.Skip(3).Take(29).ToArray();
 
                 var nodes = new NodeCollection();


### PR DESCRIPTION
Adding cancellation token support to all public APIs.
Note that the cancel action only effect the thread waiting time in the sending/waiting to response actions. This is not about sending cancel on the ZWave network.

This chance modifies many files, but all the changes are the same - add CancellationToken to the async API.
All the cancellation login is in ZWaveChannel.cs. The rest is just parameter pass through.
This should **NOT** break existing API. this only expends it.
