### PR TITLE
Remove libnserial dependency for .net core 3.0+

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Supported Targets:
 - Universal Windows: uap10.0
 - Portable Class Library: net45 + win8
 - .NET Standard: 2.0 (uses SerialPortStream package for serial port)
-- .NET Core: 2.0 (uses SerialPortStream package for serial port)
+- .NET Core: 2.0 (uses SerialPortStream package for serial port), 3.0 (no need for SerialPortStream)
 
 Runs on Raspberry PI IoT Windows 10 (see note below)
 

--- a/ZWave.core3.0/ZWave.core3.0.csproj
+++ b/ZWave.core3.0/ZWave.core3.0.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <AssemblyName>ZWave</AssemblyName>
+    <RootNamespace>Wave</RootNamespace>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DefineConstants>TRACE;DEBUG;NETCOREAPP3_0</DefineConstants>
+    <OutputPath>bin\Debug\</OutputPath>
+  </PropertyGroup>
+
+  <Import Project="..\ZWave\ZWave.projitems" Label="Shared" />
+
+  <ItemGroup>
+    <PackageReference Include="System.IO.Ports" Version="4.7.0" />
+  </ItemGroup>
+</Project>

--- a/ZWave/Channel/SerialPort.core2.cs
+++ b/ZWave/Channel/SerialPort.core2.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace ZWave.Channel
 {
-#if NETCOREAPP2_0 || NETSTANDARD2_0
+#if (NETCOREAPP2_0 || NETSTANDARD2_0) && !(NETCOREAPP3_0 || NETSTANDARD2_1)
     public class SerialPort : ISerialPort
     {
         private readonly RJCP.IO.Ports.SerialPortStream _serialPortStream;

--- a/ZWave/Channel/SerialPort.core3.cs
+++ b/ZWave/Channel/SerialPort.core3.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ZWave.Channel
+{
+#if NETCOREAPP3_0 || NETSTANDARD2_1
+    public class SerialPort : ISerialPort
+    {
+        private readonly System.IO.Ports.SerialPort _port;
+
+        public Stream InputStream
+        {
+            get { return _port.BaseStream; }
+        }
+
+        public Stream OutputStream
+        {
+            get { return _port.BaseStream; }
+        }
+
+        public SerialPort(string name)
+        {
+            _port = new System.IO.Ports.SerialPort(name, 115200, System.IO.Ports.Parity.None, 8, System.IO.Ports.StopBits.One);
+        }
+
+        public void Open()
+        {
+            _port.Open();
+            _port.DiscardInBuffer();
+            _port.DiscardOutBuffer();
+        }
+
+        public void Close()
+        {
+            _port.Close();
+        }
+    }
+#endif
+}

--- a/ZWave/Channel/ZWaveChannel.cs
+++ b/ZWave/Channel/ZWaveChannel.cs
@@ -42,7 +42,7 @@ namespace ZWave.Channel
             _semaphore = new SemaphoreSlim(1, 1);
         }
 
-#if NET || WINDOWS_UWP || NETCOREAPP2_0 || NETSTANDARD2_0
+#if NET || WINDOWS_UWP || NETCOREAPP2_0 || NETCOREAPP3_0 || NETSTANDARD2_0
         public ZWaveChannel(string portName)
              : this(new SerialPort(portName))
         {

--- a/ZWave/ZWave.projitems
+++ b/ZWave/ZWave.projitems
@@ -35,7 +35,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Channel\Protocol\TransmissionState.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Channel\Protocol\TransmitOptions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Channel\Protocol\UnknownMessage.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Channel\SerialPort.core.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Channel\SerialPort.core2.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Channel\SerialPort.core3.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Channel\SerialPort.net.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Channel\SerialPort.uap.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Channel\ZWaveChannel.cs" />

--- a/ZWave/ZWaveController.cs
+++ b/ZWave/ZWaveController.cs
@@ -30,7 +30,7 @@ namespace ZWave
         {
         }
 
-#if NET || WINDOWS_UWP || NETCOREAPP2_0 || NETSTANDARD2_0
+#if NET || WINDOWS_UWP || NETCOREAPP2_0 || NETCOREAPP3_0 || NETSTANDARD2_0
         public ZWaveController(string portName)
             : this(new ZWaveChannel(portName))
         {

--- a/ZWave4Net.nuspec
+++ b/ZWave4Net.nuspec
@@ -10,7 +10,7 @@
       - Portable Class Library: net45 + win8
       - Universal App Platform: win10
       - .NET Standard: 2.0 (uses SerialPortStream package for serial port)
-      - .NET Core: 2.0 (uses SerialPortStream package for serial port)
+      - .NET Core: 2.0 (uses SerialPortStream package for serial port), 3.0 (uses System.IO.Ports)
     </description>
     <summary>ZWave4Net is a .NET library that interfaces with the Aeotec / Aeon Labs Z-Stick</summary>
     <version>1.0.0.0</version>
@@ -22,6 +22,9 @@
       <group targetFramework="netcoreapp2.0">
         <dependency id="SerialPortStream" version="2.1.4" />
       </group>
+      <group targetFramework="netcoreapp3.0">
+        <dependency id="System.IO.Ports" version="4.7.0" />
+      </group>
       <group targetFramework="netstandard2.0">
         <dependency id="SerialPortStream" version="2.1.4" />
       </group>
@@ -32,6 +35,7 @@
     <file src="ZWave.portable-net45+win8\bin\Release\ZWave.dll" target="lib\portable-net45+win8" />
     <file src="ZWave.uap10.0\bin\Release\ZWave.dll" target="lib\uap10.0" />
     <file src="ZWave.core2.0\bin\Release\netcoreapp2.0\ZWave.dll" target="lib\netcoreapp2.0" />
+    <file src="ZWave.core3.0\bin\Release\netcoreapp3.0\ZWave.dll" target="lib\netcoreapp3.0" />
     <file src="ZWave.NetStandard2.0\bin\Release\netstandard2.0\ZWave.dll" target="lib\netstandard2.0" />
   </files>
 </package>

--- a/ZWave4Net.sln
+++ b/ZWave4Net.sln
@@ -34,7 +34,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{80711F84
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ZWaveControllerSample", "Samples\uap\ZWaveControllerSample\ZWaveControllerSample.csproj", "{FDB826C2-7368-4656-A861-2B86DB1C0E4D}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ZWave.netstandard2.0", "ZWave.NetStandard2.0\ZWave.netstandard2.0.csproj", "{6EB2D478-C016-4E31-B2F7-3C68D15F5DDC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ZWave.NetStandard2.0", "ZWave.NetStandard2.0\ZWave.NetStandard2.0.csproj", "{6EB2D478-C016-4E31-B2F7-3C68D15F5DDC}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ZWave.core2.0", "ZWave.core2.0\ZWave.core2.0.csproj", "{78066960-CBBC-4BE1-89F9-DFCCF159B205}"
 EndProject

--- a/ZWave4Net.sln
+++ b/ZWave4Net.sln
@@ -42,8 +42,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "core", "core", "{0E5FFE0D-8
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ZWaveControllerSample (core)", "Samples\core\ZWaveControllerSample (core)\ZWaveControllerSample (core).csproj", "{D4C8B1B4-D21A-46DE-AFAB-0F756D299FD5}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ZWave.core3.0", "ZWave.core3.0\ZWave.core3.0.csproj", "{1513E1DF-253C-40E5-AF85-749E5DAA8855}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		ZWave\ZWave.projitems*{1513e1df-253c-40e5-af85-749e5daa8855}*SharedItemsImports = 5
 		ZWave\ZWave.projitems*{6eb2d478-c016-4e31-b2f7-3c68d15f5ddc}*SharedItemsImports = 5
 		ZWave\ZWave.projitems*{78066960-cbbc-4be1-89f9-dfccf159b205}*SharedItemsImports = 5
 		ZWave\ZWave.projitems*{91e0ae62-9c57-4210-b3da-3ebd2e699c92}*SharedItemsImports = 13
@@ -270,6 +273,30 @@ Global
 		{D4C8B1B4-D21A-46DE-AFAB-0F756D299FD5}.Release|x64.Build.0 = Release|Any CPU
 		{D4C8B1B4-D21A-46DE-AFAB-0F756D299FD5}.Release|x86.ActiveCfg = Release|Any CPU
 		{D4C8B1B4-D21A-46DE-AFAB-0F756D299FD5}.Release|x86.Build.0 = Release|Any CPU
+		{1513E1DF-253C-40E5-AF85-749E5DAA8855}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1513E1DF-253C-40E5-AF85-749E5DAA8855}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1513E1DF-253C-40E5-AF85-749E5DAA8855}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{1513E1DF-253C-40E5-AF85-749E5DAA8855}.Debug|ARM.Build.0 = Debug|Any CPU
+		{1513E1DF-253C-40E5-AF85-749E5DAA8855}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1513E1DF-253C-40E5-AF85-749E5DAA8855}.Debug|x64.Build.0 = Debug|Any CPU
+		{1513E1DF-253C-40E5-AF85-749E5DAA8855}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1513E1DF-253C-40E5-AF85-749E5DAA8855}.Debug|x86.Build.0 = Debug|Any CPU
+		{1513E1DF-253C-40E5-AF85-749E5DAA8855}.NuGet|Any CPU.ActiveCfg = Release|Any CPU
+		{1513E1DF-253C-40E5-AF85-749E5DAA8855}.NuGet|Any CPU.Build.0 = Release|Any CPU
+		{1513E1DF-253C-40E5-AF85-749E5DAA8855}.NuGet|ARM.ActiveCfg = Debug|Any CPU
+		{1513E1DF-253C-40E5-AF85-749E5DAA8855}.NuGet|ARM.Build.0 = Debug|Any CPU
+		{1513E1DF-253C-40E5-AF85-749E5DAA8855}.NuGet|x64.ActiveCfg = Debug|Any CPU
+		{1513E1DF-253C-40E5-AF85-749E5DAA8855}.NuGet|x64.Build.0 = Debug|Any CPU
+		{1513E1DF-253C-40E5-AF85-749E5DAA8855}.NuGet|x86.ActiveCfg = Debug|Any CPU
+		{1513E1DF-253C-40E5-AF85-749E5DAA8855}.NuGet|x86.Build.0 = Debug|Any CPU
+		{1513E1DF-253C-40E5-AF85-749E5DAA8855}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1513E1DF-253C-40E5-AF85-749E5DAA8855}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1513E1DF-253C-40E5-AF85-749E5DAA8855}.Release|ARM.ActiveCfg = Release|Any CPU
+		{1513E1DF-253C-40E5-AF85-749E5DAA8855}.Release|ARM.Build.0 = Release|Any CPU
+		{1513E1DF-253C-40E5-AF85-749E5DAA8855}.Release|x64.ActiveCfg = Release|Any CPU
+		{1513E1DF-253C-40E5-AF85-749E5DAA8855}.Release|x64.Build.0 = Release|Any CPU
+		{1513E1DF-253C-40E5-AF85-749E5DAA8855}.Release|x86.ActiveCfg = Release|Any CPU
+		{1513E1DF-253C-40E5-AF85-749E5DAA8855}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -288,6 +315,7 @@ Global
 		{78066960-CBBC-4BE1-89F9-DFCCF159B205} = {15C4E1D5-BC8A-4039-B9DC-6193CB10A752}
 		{0E5FFE0D-8527-40CB-8C69-DEB62A4D50FA} = {13646915-2614-40CE-93BE-C57691FA4D06}
 		{D4C8B1B4-D21A-46DE-AFAB-0F756D299FD5} = {0E5FFE0D-8527-40CB-8C69-DEB62A4D50FA}
+		{1513E1DF-253C-40E5-AF85-749E5DAA8855} = {15C4E1D5-BC8A-4039-B9DC-6193CB10A752}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B91231ED-3737-432A-B80D-AB2092E927F8}


### PR DESCRIPTION
Starting from .net core 3.0 there is support for serial communication on Linux and macOS.