### PR TITLE
Add support for ThermostatFanMode CommandClass, 0x44

### DIFF
--- a/ZWave/Channel/CommandClass.cs
+++ b/ZWave/Channel/CommandClass.cs
@@ -13,6 +13,7 @@
         Color = 0x33,
         ThermostatMode = 0x40,
         ThermostatSetpoint = 0x43,
+        ThermostatFanMode = 0x44,
         Schedule = 0x53,
         CentralScene = 0x5B,
         MultiChannel = 0x60,

--- a/ZWave/CommandClasses/ThermostatFanMode.cs
+++ b/ZWave/CommandClasses/ThermostatFanMode.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using ZWave.Channel;
+
+namespace ZWave.CommandClasses
+{
+    public class ThermostatFanMode : EndpointSupportedCommandClassBase
+    {
+        public event EventHandler<ReportEventArgs<ThermostatFanModeReport>> Changed;
+
+        public enum command
+        {
+            Set = 0x01,
+            Get = 0x02,
+            Report = 0x03,
+            SupportedGet = 0x04,
+            SupportedReport = 0x05
+        }
+
+        public ThermostatFanMode(Node node)
+            : base(node, CommandClass.ThermostatFanMode)
+        { }
+
+        internal ThermostatFanMode(Node node, byte endpointId)
+            : base(node, CommandClass.ThermostatFanMode, endpointId)
+        { }
+
+        public Task<ThermostatFanModeReport> Get()
+        {
+            return Get(CancellationToken.None);
+        }
+
+        public async Task<ThermostatFanModeReport> Get(CancellationToken cancellationToken)
+        {
+            var response = await Send(new Command(Class, command.Get), command.Report, cancellationToken);
+            return new ThermostatFanModeReport(Node, response);
+        }
+
+        public Task Set(ThermostatFanModeValue value)
+        {
+            return Set(value, CancellationToken.None);
+        }
+
+        public async Task Set(ThermostatFanModeValue value, CancellationToken cancellationToken)
+        {
+            await Send(new Command(Class, command.Set, (byte)value), cancellationToken);
+        }
+
+        public Task<ThermostatFanModeSupportedValuesReport> GetSupportedValues()
+        {
+            return GetSupportedValues(CancellationToken.None);
+        }
+
+        public async Task<ThermostatFanModeSupportedValuesReport> GetSupportedValues(CancellationToken cancellationToken)
+        {
+            var response = await Send(new Command(Class, command.SupportedGet), command.SupportedReport, cancellationToken);
+            return new ThermostatFanModeSupportedValuesReport(Node, response);
+        }
+
+        protected internal override void HandleEvent(Command command)
+        {
+            base.HandleEvent(command);
+
+            var report = new ThermostatFanModeReport(Node, command.Payload);
+            OnChanged(new ReportEventArgs<ThermostatFanModeReport>(report));
+        }
+
+        protected virtual void OnChanged(ReportEventArgs<ThermostatFanModeReport> e)
+        {
+            var handler = Changed;
+            if (handler != null)
+            {
+                handler(this, e);
+            }
+        }
+
+    }
+}

--- a/ZWave/CommandClasses/ThermostatFanModeReport.cs
+++ b/ZWave/CommandClasses/ThermostatFanModeReport.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using ZWave.Channel.Protocol;
+
+namespace ZWave.CommandClasses
+{
+    public class ThermostatFanModeReport : NodeReport
+    {
+        public readonly ThermostatFanModeValue Mode;
+
+        internal ThermostatFanModeReport(Node node, byte[] payload) : base(node)
+        {
+            if (payload == null)
+                throw new ArgumentNullException(nameof(payload));
+            if (payload.Length < 1)
+                throw new ReponseFormatException($"The response was not in the expected format. {GetType().Name}: Payload: {BitConverter.ToString(payload)}");
+
+            Mode = (ThermostatFanModeValue)payload[0];
+        }
+
+        public override string ToString()
+        {
+            return $"Mode:{Mode}";
+        }
+    }
+}

--- a/ZWave/CommandClasses/ThermostatFanModeSupportedValuesReport.cs
+++ b/ZWave/CommandClasses/ThermostatFanModeSupportedValuesReport.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using ZWave.Channel.Protocol;
+
+namespace ZWave.CommandClasses
+{
+    public class ThermostatFanModeSupportedValuesReport : NodeReport
+    {
+        public readonly ThermostatFanModeValue[] SupportedModes;
+
+        internal ThermostatFanModeSupportedValuesReport(Node node, byte[] payload) : base(node)
+        {
+            if (payload == null)
+                throw new ArgumentNullException(nameof(payload));
+            if (payload.Length < 1)
+                throw new ReponseFormatException($"The response was not in the expected format. {GetType().Name}: Payload: {BitConverter.ToString(payload)}");
+
+            var set = new HashSet<ThermostatFanModeValue>();
+            foreach (ThermostatFanModeValue value in Enum.GetValues(typeof(ThermostatFanModeValue)))
+            {
+                int bitIndex = (int)value;
+                int byteIndex = bitIndex / 8;
+
+                if (byteIndex >= payload.Length)
+                {
+                    break;
+                }
+
+                byte currentByte = payload[byteIndex];
+
+                uint bit = 1U << (bitIndex % 8);
+                if ((bit & currentByte) == bit)
+                {
+                    set.Add(value);
+                }
+            }
+
+            SupportedModes = set.ToArray();
+        }
+
+        public override string ToString()
+        {
+            return $"SupportedModes:{SupportedModes}";
+        }
+    }
+}

--- a/ZWave/CommandClasses/ThermostatFanModeValue.cs
+++ b/ZWave/CommandClasses/ThermostatFanModeValue.cs
@@ -1,0 +1,24 @@
+﻿namespace ZWave.CommandClasses
+{
+    public enum ThermostatFanModeValue : byte
+    {
+        AutoLow = 0x00,
+        Low = 0x01,
+        AutoHigh = 0x02,
+        High = 0x03,
+        AutoMedium = 0x04,
+        Medium = 0x05,
+        Circulation = 0x06,
+        HumidityCirculation = 0x07,
+        LeftAndRight = 0x08,
+        UpAndDown = 0x09,
+        Quiet = 0x0A,
+        ExternalCirculation = 0x0B,
+        EnergyCool = 0x0C,
+        Away = 0x0D,
+        Reserved = 0x0E,
+        FullPower = 0x0F,
+        ManufacturerSpecific = 0x1F
+    };
+}
+

--- a/ZWave/CommandClasses/ThermostatFanModeValue.cs
+++ b/ZWave/CommandClasses/ThermostatFanModeValue.cs
@@ -13,12 +13,7 @@
         LeftAndRight = 0x08,
         UpAndDown = 0x09,
         Quiet = 0x0A,
-        ExternalCirculation = 0x0B,
-        EnergyCool = 0x0C,
-        Away = 0x0D,
-        Reserved = 0x0E,
-        FullPower = 0x0F,
-        ManufacturerSpecific = 0x1F
+        ExternalCirculation = 0x0B
     };
 }
 

--- a/ZWave/Node.cs
+++ b/ZWave/Node.cs
@@ -55,6 +55,7 @@ namespace ZWave
             _commandClasses.Add(new MultiChannel(this));
             _commandClasses.Add(new ThermostatMode(this));
             _commandClasses.Add(new ThermostatSetpoint(this));
+            _commandClasses.Add(new ThermostatFanMode(this));
             _commandClasses.Add(new Schedule(this));
             _commandClasses.Add(new Clock(this));
             _commandClasses.Add(new CentralScene(this));

--- a/ZWave/ZWave.projitems
+++ b/ZWave/ZWave.projitems
@@ -48,7 +48,11 @@
     <Compile Include="$(MSBuildThisFileDirectory)CommandClasses\ScheduleSupportedCommandClass.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CommandClasses\ScheduleSupportedFunctionalitiesReport.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CommandClasses\ScheduleReport.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)CommandClasses\ThermostatFanMode.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)CommandClasses\ThermostatFanModeReport.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)CommandClasses\ThermostatFanModeSupportedValuesReport.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CommandClasses\ThermostatModeSupportedValuesReport.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)CommandClasses\ThermostatFanModeValue.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CommandClasses\ThermostatModeValue.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CommandClasses\AlarmType.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CommandClasses\Association.cs" />


### PR DESCRIPTION
The values for the ThermostatFanModeValue enum were taken from Section 4.106.1 "Thermostat Fan Mode Set Command" of the spec located [here](https://www.silabs.com/documents/login/miscellaneous/SDS13781-Z-Wave-Application-Command-Class-Specification.pdf).


