### PR TITLE
Add ThermostatOperatingState command class.

### DIFF
--- a/ZWave/Channel/CommandClass.cs
+++ b/ZWave/Channel/CommandClass.cs
@@ -15,6 +15,7 @@
         ThermostatOperatingState = 0x42,
         ThermostatSetpoint = 0x43,
         ThermostatFanMode = 0x44,
+        ThermostatFanState = 0x45,
         Schedule = 0x53,
         CentralScene = 0x5B,
         MultiChannel = 0x60,

--- a/ZWave/Channel/CommandClass.cs
+++ b/ZWave/Channel/CommandClass.cs
@@ -12,6 +12,7 @@
         Meter = 0x32,
         Color = 0x33,
         ThermostatMode = 0x40,
+        ThermostatOperatingState = 0x42,
         ThermostatSetpoint = 0x43,
         ThermostatFanMode = 0x44,
         Schedule = 0x53,

--- a/ZWave/CommandClasses/ThermostatFanState.cs
+++ b/ZWave/CommandClasses/ThermostatFanState.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using ZWave.Channel;
+
+namespace ZWave.CommandClasses
+{
+    public class ThermostatFanState : CommandClassBase
+    {
+        public event EventHandler<ReportEventArgs<ThermostatFanStateReport>> Changed;
+
+        public enum command
+        {
+            Get = 0x02,
+            Report = 0x03
+        }
+
+        public ThermostatFanState(Node node)
+            : base(node, CommandClass.ThermostatFanState)
+        { }
+
+        public Task<ThermostatFanStateReport> Get()
+        {
+            return Get(CancellationToken.None);
+        }
+
+        public async Task<ThermostatFanStateReport> Get(CancellationToken cancellationToken)
+        {
+            var response = await Channel.Send(Node, new Command(Class, command.Get), command.Report, cancellationToken);
+            return new ThermostatFanStateReport(Node, response);
+        }
+
+        protected internal override void HandleEvent(Command command)
+        {
+            base.HandleEvent(command);
+
+            var report = new ThermostatFanStateReport(Node, command.Payload);
+            OnChanged(new ReportEventArgs<ThermostatFanStateReport>(report));
+        }
+
+        protected virtual void OnChanged(ReportEventArgs<ThermostatFanStateReport> e)
+        {
+            var handler = Changed;
+            if (handler != null)
+            {
+                handler(this, e);
+            }
+        }
+
+    }
+}

--- a/ZWave/CommandClasses/ThermostatFanStateReport.cs
+++ b/ZWave/CommandClasses/ThermostatFanStateReport.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using ZWave.Channel.Protocol;
+
+namespace ZWave.CommandClasses
+{
+    public class ThermostatFanStateReport : NodeReport
+    {
+        public readonly ThermostatFanStateValue Value;
+
+        internal ThermostatFanStateReport(Node node, byte[] payload) : base(node)
+        {
+            if (payload == null)
+                throw new ArgumentNullException(nameof(payload));
+            if (payload.Length < 1)
+                throw new ReponseFormatException($"The response was not in the expected format. {GetType().Name}: Payload: {BitConverter.ToString(payload)}");
+
+            Value = (ThermostatFanStateValue)payload[0];
+        }
+
+        public override string ToString()
+        {
+            return $"Value:{Value}";
+        }
+    }
+}

--- a/ZWave/CommandClasses/ThermostatFanStateValue.cs
+++ b/ZWave/CommandClasses/ThermostatFanStateValue.cs
@@ -1,0 +1,9 @@
+﻿namespace ZWave.CommandClasses
+{
+    public enum ThermostatFanStateValue : byte
+    {
+        Off = 0x00,
+        Running = 0x01,
+    };
+}
+

--- a/ZWave/CommandClasses/ThermostatOperatingState.cs
+++ b/ZWave/CommandClasses/ThermostatOperatingState.cs
@@ -5,7 +5,7 @@ using ZWave.Channel;
 
 namespace ZWave.CommandClasses
 {
-    public class ThermostatOperatingState : EndpointSupportedCommandClassBase
+    public class ThermostatOperatingState : CommandClassBase
     {
         public event EventHandler<ReportEventArgs<ThermostatOperatingStateReport>> Changed;
 
@@ -19,10 +19,6 @@ namespace ZWave.CommandClasses
             : base(node, CommandClass.ThermostatOperatingState)
         { }
 
-        internal ThermostatOperatingState(Node node, byte endpointId)
-            : base(node, CommandClass.ThermostatOperatingState, endpointId)
-        { }
-
         public Task<ThermostatOperatingStateReport> Get()
         {
             return Get(CancellationToken.None);
@@ -30,7 +26,7 @@ namespace ZWave.CommandClasses
 
         public async Task<ThermostatOperatingStateReport> Get(CancellationToken cancellationToken)
         {
-            var response = await Send(new Command(Class, command.Get), command.Report, cancellationToken);
+            var response = await Channel.Send(Node, new Command(Class, command.Get), command.Report, cancellationToken);
             return new ThermostatOperatingStateReport(Node, response);
         }
 

--- a/ZWave/CommandClasses/ThermostatOperatingState.cs
+++ b/ZWave/CommandClasses/ThermostatOperatingState.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using ZWave.Channel;
+
+namespace ZWave.CommandClasses
+{
+    public class ThermostatOperatingState : EndpointSupportedCommandClassBase
+    {
+        public event EventHandler<ReportEventArgs<ThermostatOperatingStateReport>> Changed;
+
+        public enum command
+        {
+            Get = 0x02,
+            Report = 0x03
+        }
+
+        public ThermostatOperatingState(Node node)
+            : base(node, CommandClass.ThermostatOperatingState)
+        { }
+
+        internal ThermostatOperatingState(Node node, byte endpointId)
+            : base(node, CommandClass.ThermostatOperatingState, endpointId)
+        { }
+
+        public Task<ThermostatOperatingStateReport> Get()
+        {
+            return Get(CancellationToken.None);
+        }
+
+        public async Task<ThermostatOperatingStateReport> Get(CancellationToken cancellationToken)
+        {
+            var response = await Send(new Command(Class, command.Get), command.Report, cancellationToken);
+            return new ThermostatOperatingStateReport(Node, response);
+        }
+
+        protected internal override void HandleEvent(Command command)
+        {
+            base.HandleEvent(command);
+
+            var report = new ThermostatOperatingStateReport(Node, command.Payload);
+            OnChanged(new ReportEventArgs<ThermostatOperatingStateReport>(report));
+        }
+
+        protected virtual void OnChanged(ReportEventArgs<ThermostatOperatingStateReport> e)
+        {
+            var handler = Changed;
+            if (handler != null)
+            {
+                handler(this, e);
+            }
+        }
+
+    }
+}

--- a/ZWave/CommandClasses/ThermostatOperatingStateReport.cs
+++ b/ZWave/CommandClasses/ThermostatOperatingStateReport.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using ZWave.Channel.Protocol;
+
+namespace ZWave.CommandClasses
+{
+    public class ThermostatOperatingStateReport : NodeReport
+    {
+        public readonly ThermostatOperatingStateValue Value;
+
+        internal ThermostatOperatingStateReport(Node node, byte[] payload) : base(node)
+        {
+            if (payload == null)
+                throw new ArgumentNullException(nameof(payload));
+            if (payload.Length < 1)
+                throw new ReponseFormatException($"The response was not in the expected format. {GetType().Name}: Payload: {BitConverter.ToString(payload)}");
+
+            Value = (ThermostatOperatingStateValue)payload[0];
+        }
+
+        public override string ToString()
+        {
+            return $"Value:{Value}";
+        }
+    }
+}

--- a/ZWave/CommandClasses/ThermostatOperatingStateValue.cs
+++ b/ZWave/CommandClasses/ThermostatOperatingStateValue.cs
@@ -1,0 +1,17 @@
+﻿namespace ZWave.CommandClasses
+{
+    public enum ThermostatOperatingStateValue : byte
+    {
+        Idle = 0x00,
+        Heating = 0x01,
+        Cooling = 0x02,
+        FanOnly = 0x03,
+        PendingHeat = 0x04,
+        PendingCool = 0x05,
+        VentEconomizer = 0x06,
+        AuxHeating = 0x07,
+        SecondStageHeating = 0x08,
+        SecondStageCooling = 0x09,
+    };
+}
+

--- a/ZWave/Node.cs
+++ b/ZWave/Node.cs
@@ -54,6 +54,7 @@ namespace ZWave
             _commandClasses.Add(new Color(this));
             _commandClasses.Add(new MultiChannel(this));
             _commandClasses.Add(new ThermostatMode(this));
+            _commandClasses.Add(new ThermostatOperatingState(this));
             _commandClasses.Add(new ThermostatSetpoint(this));
             _commandClasses.Add(new ThermostatFanMode(this));
             _commandClasses.Add(new Schedule(this));

--- a/ZWave/Node.cs
+++ b/ZWave/Node.cs
@@ -57,6 +57,7 @@ namespace ZWave
             _commandClasses.Add(new ThermostatOperatingState(this));
             _commandClasses.Add(new ThermostatSetpoint(this));
             _commandClasses.Add(new ThermostatFanMode(this));
+            _commandClasses.Add(new ThermostatFanState(this));
             _commandClasses.Add(new Schedule(this));
             _commandClasses.Add(new Clock(this));
             _commandClasses.Add(new CentralScene(this));

--- a/ZWave/ZWave.projitems
+++ b/ZWave/ZWave.projitems
@@ -51,6 +51,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)CommandClasses\ThermostatFanMode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CommandClasses\ThermostatFanModeReport.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CommandClasses\ThermostatFanModeSupportedValuesReport.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)CommandClasses\ThermostatFanState.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)CommandClasses\ThermostatFanStateReport.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)CommandClasses\ThermostatFanStateValue.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CommandClasses\ThermostatOperatingStateValue.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CommandClasses\ThermostatOperatingStateReport.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CommandClasses\ThermostatOperatingState.cs" />

--- a/ZWave/ZWave.projitems
+++ b/ZWave/ZWave.projitems
@@ -51,6 +51,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)CommandClasses\ThermostatFanMode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CommandClasses\ThermostatFanModeReport.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CommandClasses\ThermostatFanModeSupportedValuesReport.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)CommandClasses\ThermostatOperatingStateValue.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)CommandClasses\ThermostatOperatingStateReport.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)CommandClasses\ThermostatOperatingState.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CommandClasses\ThermostatModeSupportedValuesReport.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CommandClasses\ThermostatFanModeValue.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CommandClasses\ThermostatModeValue.cs" />


### PR DESCRIPTION
This adds the ThermostatOperatingState and ThermostatFanState command classes to the library. For ThermostatOperatingState I included the values from v2 of the spec as well, but the thermostat (Honeywell T6 Pro Z-Wave) I used to test this only supports v1 for both of these states.