### PR TITLE
Reset the serial connection following the public user guide process

### DIFF
--- a/Source/ZWave/Channel/ZWaveChannel.cs
+++ b/Source/ZWave/Channel/ZWaveChannel.cs
@@ -293,6 +293,12 @@ namespace ZWave.Channel
             _portReadTask.Start();
             _processEventsTask.Start();
             _transmitTask.Start();
+
+            //Reset Serial Connection
+            _transmitQueue.Add(Message.NAK);
+            var request = new ControllerFunction(Function.SerialApiSoftReset);
+            _transmitQueue.Add(request);
+            Task.Delay(1500).Wait();
         }
 
         public void Close()


### PR DESCRIPTION
This adds a small delay to new connections but eliminates the invalid state problem in controllers without a hard reset capability.